### PR TITLE
Feat/dockerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ After that you can run or stop postfwd using systemd, init or script `/etc/init.
 
 To change default arguments with which postfwd is run, edit file `/etc/default/postfwd`.
 
+### Docker
+
+You have 2 options:
+
+1. Pull Postfwd Docker from DockerHub using `docker pull postfwd/postfwd`.
+2. Build it locally using `docker build docker/` from root directory of this git repository.
+
+After that, you can prepare configuration file `postfwd.cf` and run Docker container with volume path pointing to host directory with your configuration file.
+
+For example, if you have configuration `postfwd.cf` on host in directory `/opt/postfwd/` and want to expose container port `10040` on host port `10040`, run Postfwd Docker with command:
+
+```bash
+docker run -d \
+    -p 10040:10040 \
+    -v /opt/postfwd/:/etc/postfwd/ \
+    postfwd/postfwd
+```
+
 ### Manual installation
 
 Clone this repository and copy `postfwd2` from directory `./sbin` to your PATH environment (eg. /usr/sbin/).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:stretch-slim
+
+LABEL maintainer="Postfwd Docker Maintainer <info@jpkessler.de>"
+
+RUN apt-get update && \
+    apt-get install -y postfwd
+
+ARG PORT=10040
+
+RUN mkdir /etc/postfwd
+VOLUME /etc/postfwd
+
+EXPOSE $PORT
+
+COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]
+
+CMD ["/usr/sbin/postfwd2", \
+     "--file", "/etc/postfwd/postfwd.cf", \
+     "--user", "postfw", \
+     "--group", "postfw", \
+     "--stdout"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+"$@"
+
+sleep infinity


### PR DESCRIPTION
This merge request add possibilty to use postfwd in Docker container.

Postfwd Docker container runs with default arguments, which can be overriden as usually in docker command `docker run`. Nice thing about having postfwd in Docker container is that you are keeping your system packages clean. This also makes installation very simple on OSs where postfwd must be installed manually (RH based or other). 

Postfwd cannot be run straightforward as CMD/ENTRYPOINT, because it creates master process which spawns childs and then exits which causes whole container to exit with it. If Postfwd had option to keep master process in foreground, then script `docker-entrypoint.sh` would not be necessary.

Because of this, I used `sleep infinity` the end of script `docker-entrypoint.sh` to keep process alive.

> Ugliest thing about this is that I needed to use some placeholder command to keep entrypoint script alive and that command is `tail -f -n0 -q /dev/null`. 
> 
> Discussion about this issue: https://stackoverflow.com/questions/25775266/how-to-keep-docker-container-running-after-starting-services/30632659#30632659

I would like to ask you to create DockerHub repository to make webhook for GitHub. This will cause DockerHub to recreate container on commits into selected branch. Path must be updated to /docker.

As second thing it will allow to download postfwd straight from DockerHub without building. This is very nice because I can inherit this container in my postfwd plugin repository, where I will take it as base image and install all dependencies very easily, which will in the end simplify usage of that plugin.

This can be done for other purposes of course. 