### PR TITLE
feature: warn about = for regex

### DIFF
--- a/doc/postfwd3.CHANGELOG
+++ b/doc/postfwd3.CHANGELOG
@@ -1,3 +1,20 @@
+postfwd3 2.XX
+=============
+- feature: Added warnings for use of = to specify a regex in an item,
+           due to this historical behaviour sometimes causing subtle
+		   misconfigurations, e.g. sender=alice@example.org matching
+		   malice@exampleforged.com.
+
+           If you encounter these warnings, please review your
+		   configuration, change to =~ if a regex match is intended,
+		   or perhaps == for a literal match if appropriate. Note that
+		   =~ does not allow the use of // around its argument, so remove
+		   those if present.
+
+		   These warnings are enabled by default, and can be suppressed
+		   with --allow_default_regex, or turned into fatal errors with
+		   --forbid_default_regex.
+
 postfwd3 2.03
 =============
 - bugfix:  Corrected bug with --delrate command in v1 mode

--- a/sbin/postfwd3
+++ b/sbin/postfwd3
@@ -1398,8 +1398,8 @@ sub parse_config_line {
 					if ($postfwd_settings{forbid_default_regex}) {
 						log_crit ("Possible accidental use of = at $myfile line $mynum, and --forbid_default_regex is set. Exiting!");
 						end_program();
-					}
-				}
+					};
+				};
 			};
 			unless (exists($myrule{$COMP_ACTION})) {
 				log_warn ("Rule ".$myindex." ($myfile line ".$mynum."): contains no action and will be ignored");

--- a/sbin/postfwd3
+++ b/sbin/postfwd3
@@ -1393,8 +1393,8 @@ sub parse_config_line {
 				} else {
 					push @{$myrule{$mykey}}, prepare_item ($forced_reload, $mycomp, $myvalue);
 				};
-				if (!$postfwd_settings{allow_default_regex} && $mykey !~ /^($COMP_ACTION|$COMP_ID|)$/ && $mycomp eq "=" && !(defined $postfwd_compare{$mykey})) {
-					log_warn ("Rule ".$myindex." ($myfile line ".$mynum."): possible accidental use of = ($myvalue is treated as a regex). If this is correct, use =~ to suppress this warning. If a literal match is intended, use == instead.");
+				if (!$postfwd_settings{allow_default_regex} && $mykey !~ /^($COMP_ACTION|$COMP_ID)$/ && $mycomp eq "=" && !(defined $postfwd_compare{$mykey})) {
+					log_warn ("Rule ".$myindex." ($myfile line ".$mynum."): possible accidental use of = ($myvalue is treated as a regex). If this is correct, use =~ to avoid this warning. If a literal match is intended, use == instead.");
 					if ($postfwd_settings{forbid_default_regex}) {
 						log_crit ("Possible accidental use of = at $myfile line $mynum, and --forbid_default_regex is set. Exiting!");
 						end_program();

--- a/sbin/postfwd3
+++ b/sbin/postfwd3
@@ -1393,6 +1393,13 @@ sub parse_config_line {
 				} else {
 					push @{$myrule{$mykey}}, prepare_item ($forced_reload, $mycomp, $myvalue);
 				};
+				if (!$postfwd_settings{allow_default_regex} && $mykey !~ /^($COMP_ACTION|$COMP_ID|)$/ && $mycomp eq "=" && !(defined $postfwd_compare{$mykey})) {
+					log_warn ("Rule ".$myindex." ($myfile line ".$mynum."): possible accidental use of = ($myvalue is treated as a regex). If this is correct, use =~ to suppress this warning. If a literal match is intended, use == instead.");
+					if ($postfwd_settings{forbid_default_regex}) {
+						log_crit ("Possible accidental use of = at $myfile line $mynum, and --forbid_default_regex is set. Exiting!");
+						end_program();
+					}
+				}
 			};
 			unless (exists($myrule{$COMP_ACTION})) {
 				log_warn ("Rule ".$myindex." ($myfile line ".$mynum."): contains no action and will be ignored");
@@ -3383,6 +3390,8 @@ GetOptions( \%options,
 	"aggregate_addrs|A!",
 	"showconfig|C",
 	"defaults|D",
+	"allow_default_regex"	  => \$postfwd_settings{allow_default_regex},
+	"forbid_default_regex"	  => \$postfwd_settings{forbid_default_regex},
 	# Networking
 	"umask=s"		  => \$postfwd_settings{base}{umask},
 	"user|u=s"		  => \$postfwd_settings{base}{user},
@@ -3518,6 +3527,8 @@ map { $postfwd_settings{$_}{check} = ($postfwd_settings{$_}{proto} eq 'unix') ? 
 
 # de-taint command-line
 %postfwd_settings = detaint_hash (%postfwd_settings);
+
+die "\nERROR: --allow_default_regex and --forbid_default_regex can not be used at the same time!\n\n" if ($postfwd_settings{allow_default_regex} && $postfwd_settings{forbid_default_regex});
 
 # check for commands (e.g. 'postfwd stop')
 if (@ARGV) {
@@ -4062,6 +4073,8 @@ B<postfwd3> [OPTIONS] --cmd [SOURCE1, SOURCE2, ...]
 	    --no_netaddr		don't use NetAddr::IP functions
 	    --no_netcidr		don't use Net::CIDR::Lite functions
 	    --cidr_method=s		use method <s> for network checks
+	    --allow_default_regex	don't warn for using = to indicate a regex (e.g. allow sender=^alice@example\.org$)
+	    --forbid_default_regex	treat using = to indicate a regex as an error (e.g. forbid sender=alice@example.org)
 
 
 	Plugins:
@@ -4279,8 +4292,27 @@ postfwd versions prior to 1.30 require trailing ';' and '\'-characters:
 Besides these you can specify any attribute of the postfix policy delegation protocol.  
 Feel free to combine them the way you need it (have a look at the EXAMPLES section below).
 
-Most values can be specified as regular expressions (PCRE). Please see the table below
-for details:
+B<Warning>
+
+For historical reasons, most values are treated as regular expressions (PCRE) by default, when using the = operator. This can
+cause undesired behaviour, e.g. if sender=alice@example.org is specified, this will also match malice@exampleforged.com, because
+"alice@example.com" is treated as a regex.
+
+This has the potential to cause unsafe configuration files, so writing items in this format has been deprecated, but it is still
+supported to not break existing rulesets.
+
+Instead, it's best to use == when a literal match is desired (e.g. sender==alice@example.org). If a regex is desired, it's best
+to indicate this explicitly, e.g. by writing sender=~^alice@example\.org instead. 
+
+If postfwd encounters a potentially unsafely defined item such as sender=alice@example.com, postfwd will issue a warning. The
+option --allow_default_regex can be used to suppress this warning. The option --forbid_default_regex can also be used to turn
+this warning into a fatal error (useful to catch making a mistake before it causes a problem).
+
+The = operator must still be used for id, action, and for any of the items below that have custom matching rules, and will not
+cause a warning. E.g. it still makes sense to write client_address=192.0.2.0/24, because of the custom matching logic for IP
+addresses.
+
+Please see the table below for details:
 
 	# ==========================================================
 	# ITEM=VALUE				TYPE


### PR DESCRIPTION
As briefly discussed on the mailing list on 16/10 and 18/10.

Added warnings for use of = to specify a regex in an item, due to this historical behaviour sometimes causing subtle misconfigurations, e.g. sender=alice@example.org matching malice@exampleforged.com.

Also added --allow_default_regex and --forbid_default_regex, which allows the user to disable this behaviour, or enforce these warnings as errors.